### PR TITLE
Fix: Include name field in credentials update request

### DIFF
--- a/src/components/StudentDataSplash.tsx
+++ b/src/components/StudentDataSplash.tsx
@@ -214,6 +214,7 @@ export const StudentDataSplash = ({ isOpen, onDataComplete, membershipStatus, on
     setIsSaving(true);
     try {
       const response = await api.post('api/client/profile/update-credentials', {
+        name: user?.name || '',
         email: email,
         password: password,
         password_confirmation: confirmPassword,


### PR DESCRIPTION
- Added user.name field to API request in updatePasswordAndEmail method
- Fixes validation error when backend requires name field
- Resolves issue where users with existing names couldn't complete setup